### PR TITLE
Add multi-calendar support: persist calendar_id, include in API calls and UI

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -8,6 +8,7 @@ from telegram.ext import ContextTypes
 from orchestrator.router import process_message
 from orchestrator.confirmation_queue import add_pending_write, confirm_write, reject_write, get_pending_write
 from orchestrator.trigger_scheduler import queue_trigger, consume_trigger
+from integrations.calendar import resolve_calendar_display_name
 from orchestrator.session_manager import (
     start_session, end_session, reset_session_timeout, cancel_session_timeout, get_session_state,
     is_session_active, track_confirmation_message, get_tracked_confirmation_messages, 
@@ -87,11 +88,29 @@ async def send_calendar_proposal(context: ContextTypes.DEFAULT_TYPE, chat_id: in
     start_dt = parse_user_datetime(action.start_time)
     end_dt = parse_user_datetime(action.end_time)
     
-    write_id = add_pending_write(action.summary, start_dt, end_dt, action.description)
+    write_id = add_pending_write(
+        action.summary,
+        start_dt,
+        end_dt,
+        action.description,
+        action.calendar_id,
+    )
     reply_markup = build_calendar_confirmation_keyboard(write_id)
     
+    calendar_name = await asyncio.to_thread(resolve_calendar_display_name, action.calendar_id)
+    calendar_line = (
+        f"Calendar: {calendar_name} (`{action.calendar_id}`)"
+        if calendar_name != action.calendar_id
+        else f"Calendar ID: `{action.calendar_id}`"
+    )
+
     full_text = f"{prefix_text}\n\n" if prefix_text else ""
-    full_text += f"🗓️ *Proposed Event:*\n*{action.summary}*\n_{action.description}_\n\nStart: {format_user_datetime(start_dt)}\nEnd: {format_user_datetime(end_dt)}"
+    full_text += (
+        f"🗓️ *Proposed Event:*\n*{action.summary}*\n_{action.description}_\n\n"
+        f"{calendar_line}\n"
+        f"Start: {format_user_datetime(start_dt)}\n"
+        f"End: {format_user_datetime(end_dt)}"
+    )
     
     message = await context.bot.send_message(
         chat_id=chat_id,

--- a/integrations/calendar.py
+++ b/integrations/calendar.py
@@ -20,6 +20,26 @@ def get_calendar_service():
         logger.error(f"Failed to build Calendar service: {e}")
         raise
 
+def resolve_calendar_display_name(calendar_id: str) -> str:
+    """
+    Returns a human-friendly calendar name for a calendar ID.
+    Falls back to the raw calendar_id when no summary is available.
+    """
+    if calendar_id == "primary":
+        return "Primary"
+
+    service = get_calendar_service()
+    try:
+        calendar_list = service.calendarList().list().execute()
+        for calendar in calendar_list.get("items", []):
+            if calendar.get("id") == calendar_id:
+                return calendar.get("summary", calendar_id)
+    except HttpError as error:
+        logger.warning(f"Could not resolve display name for calendar {calendar_id}: {error}")
+    except Exception as error:
+        logger.warning(f"Unexpected error resolving calendar display name for {calendar_id}: {error}")
+    return calendar_id
+
 def get_upcoming_events(days: int = 7) -> list:
     """
     Fetches the upcoming events across all of the user's calendars.
@@ -46,7 +66,10 @@ def get_upcoming_events(days: int = 7) -> list:
                     singleEvents=True,
                     orderBy='startTime'
                 ).execute()
-                all_events.extend(events_result.get('items', []))
+                calendar_events = events_result.get('items', [])
+                for event in calendar_events:
+                    event.setdefault("calendar_id", cal_id)
+                all_events.extend(calendar_events)
             except HttpError as e:
                 logger.warning(f"Could not fetch events for calendar {cal.get('summary', cal_id)}: {e}")
                 
@@ -85,7 +108,10 @@ def get_past_events(days: int = 7) -> list:
                     calendarId=cal_id, timeMin=past_iso, timeMax=now_iso,
                     singleEvents=True, orderBy='startTime'
                 ).execute()
-                all_events.extend(events_result.get('items', []))
+                calendar_events = events_result.get('items', [])
+                for event in calendar_events:
+                    event.setdefault("calendar_id", cal_id)
+                all_events.extend(calendar_events)
             except HttpError as e:
                 logger.warning(f"Could not fetch past events for calendar {cal.get('summary', cal_id)}: {e}")
                 
@@ -98,9 +124,15 @@ def get_past_events(days: int = 7) -> list:
         logger.error(f"An error occurred fetching past events: {error}")
         return []
 
-def insert_event(summary: str, start_time: datetime, end_time: datetime, description: str = "") -> dict:
+def insert_event(
+    summary: str,
+    start_time: datetime,
+    end_time: datetime,
+    description: str = "",
+    calendar_id: str = "primary",
+) -> dict:
     """
-    Inserts a new event into the user's primary calendar.
+    Inserts a new event into the selected calendar.
     """
     if start_time.tzinfo is None or end_time.tzinfo is None:
         raise ValueError("start_time and end_time must be timezone-aware datetime objects.")
@@ -122,8 +154,9 @@ def insert_event(summary: str, start_time: datetime, end_time: datetime, descrip
                 'timeZone': 'America/Toronto',
             },
         }
-        logger.info(f"Inserting event: '{summary}'...")
-        created_event = service.events().insert(calendarId='primary', body=event_body).execute()
+        logger.info(f"Inserting event: '{summary}' into calendar '{calendar_id}'...")
+        created_event = service.events().insert(calendarId=calendar_id, body=event_body).execute()
+        created_event.setdefault("calendar_id", created_event.get("calendarId", calendar_id))
         return created_event
     except HttpError as error:
         logger.error(f"An error occurred inserting the event: {error}")

--- a/orchestrator/confirmation_queue.py
+++ b/orchestrator/confirmation_queue.py
@@ -13,7 +13,13 @@ from persistence.models import CalendarWriteRecord, CalendarWriteStatus
 # The user can then confirm or reject these pending writes through the Telegram bot interface, which will call the confirm_write or reject_write functions.
 # Confirmation queue is necessary to ensure that David does not make any calendar changes without explicit user approval, adding a layer of safety and control.
 
-def add_pending_write(summary: str, start_time: datetime, end_time: datetime, description: str = "") -> str:
+def add_pending_write(
+    summary: str,
+    start_time: datetime,
+    end_time: datetime,
+    description: str = "",
+    calendar_id: str = "primary",
+) -> str:
     """
     Adds a proposed calendar write to the database and returns its unique ID.
     """
@@ -27,6 +33,7 @@ def add_pending_write(summary: str, start_time: datetime, end_time: datetime, de
         start_time=start_time.isoformat(),
         end_time=end_time.isoformat(),
         description=description,
+        calendar_id=calendar_id,
         status=CalendarWriteStatus.PENDING,
         created_at=now_iso
     )
@@ -76,11 +83,19 @@ def confirm_write(write_id: str) -> Optional[dict]:
         summary=record.summary,
         start_time=start_dt,
         end_time=end_dt,
-        description=record.description
+        description=record.description,
+        calendar_id=record.calendar_id,
     )
     
     if created_event:
-        db["calendar_writes"].update(write_id, {"status": CalendarWriteStatus.EXECUTED.value})  # type: ignore
+        db["calendar_writes"].update(
+            write_id,
+            {
+                "status": CalendarWriteStatus.EXECUTED.value,
+                "created_event_id": created_event.get("id"),
+                "created_event_calendar_id": created_event.get("calendar_id", record.calendar_id),
+            },
+        )  # type: ignore
         logger.success(f"Successfully executed write {write_id} to Google Calendar.")
         # Return created_event for caching within same session
         return created_event

--- a/persistence/database.py
+++ b/persistence/database.py
@@ -39,10 +39,25 @@ def init_db():
             "start_time": str,  # ISO format
             "end_time": str,    # ISO format
             "description": str,
+            "calendar_id": str,
             "status": str,      # pending, confirmed, rejected, executed
-            "created_at": str
+            "created_at": str,
+            "created_event_id": str,
+            "created_event_calendar_id": str,
         }, pk="id")
         logger.info("Created table: calendar_writes")
+    else:
+        table = db["calendar_writes"]
+        existing_columns = {column.name for column in table.columns}
+        if "calendar_id" not in existing_columns:
+            table.add_column("calendar_id", str, default="primary")
+            logger.info("Added column calendar_writes.calendar_id")
+        if "created_event_id" not in existing_columns:
+            table.add_column("created_event_id", str)
+            logger.info("Added column calendar_writes.created_event_id")
+        if "created_event_calendar_id" not in existing_columns:
+            table.add_column("created_event_calendar_id", str)
+            logger.info("Added column calendar_writes.created_event_calendar_id")
 
     # 2. Sessions
     if "sessions" not in db.table_names():

--- a/persistence/models.py
+++ b/persistence/models.py
@@ -21,8 +21,11 @@ class CalendarWriteRecord(BaseModel):
     start_time: str
     end_time: str
     description: str
+    calendar_id: str = "primary"
     status: CalendarWriteStatus
     created_at: str
+    created_event_id: Optional[str] = None
+    created_event_calendar_id: Optional[str] = None
 
 class SessionRecord(BaseModel):
     id: str

--- a/reasoning/schemas.py
+++ b/reasoning/schemas.py
@@ -6,3 +6,4 @@ class ProposedEvent(BaseModel):
     start_time: str = Field(description="The event start time in timezone-aware ISO 8601 format, including a UTC offset, e.g., 2026-03-22T09:00:00-04:00")
     end_time: str = Field(description="The event end time in timezone-aware ISO 8601 format, including a UTC offset, e.g., 2026-03-22T11:00:00-04:00")
     description: str = Field(description="A brief description of the event's purpose.")
+    calendar_id: str = Field(default="primary", description="Target Google Calendar ID. Use 'primary' when no specific calendar is requested.")

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,7 +1,12 @@
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
-from integrations.calendar import get_past_events, get_upcoming_events, insert_event
+from integrations.calendar import (
+    get_past_events,
+    get_upcoming_events,
+    insert_event,
+    resolve_calendar_display_name,
+)
 
 
 @patch("integrations.calendar.get_calendar_service")
@@ -14,12 +19,13 @@ def test_insert_event_sends_toronto_datetime_and_timezone(mock_get_calendar_serv
         summary="Deep Work",
         start_time=datetime.fromisoformat("2026-03-31T13:00:00+00:00"),
         end_time=datetime.fromisoformat("2026-03-31T14:30:00+00:00"),
-        description="Focus block."
+        description="Focus block.",
+        calendar_id="team_calendar@example.com",
     )
 
-    assert created_event == {"id": "evt_123"}
+    assert created_event == {"id": "evt_123", "calendar_id": "team_calendar@example.com"}
     insert_kwargs = mock_service.events.return_value.insert.call_args.kwargs
-    assert insert_kwargs["calendarId"] == "primary"
+    assert insert_kwargs["calendarId"] == "team_calendar@example.com"
     assert insert_kwargs["body"]["start"] == {
         "dateTime": "2026-03-31T09:00:00-04:00",
         "timeZone": "America/Toronto",
@@ -58,6 +64,7 @@ def test_get_upcoming_events_returns_earliest_first_across_calendars(mock_get_ca
         "Earlier Event",
         "Later Event",
     ]
+    assert [event["calendar_id"] for event in events] == ["cal_2", "cal_2", "cal_1"]
 
 
 @patch("integrations.calendar.get_calendar_service")
@@ -86,3 +93,21 @@ def test_get_past_events_returns_earliest_first_across_calendars(mock_get_calend
         "Monday Event",
         "Tuesday Event",
     ]
+    assert [event["calendar_id"] for event in events] == ["cal_2", "cal_1"]
+
+
+@patch("integrations.calendar.get_calendar_service")
+def test_resolve_calendar_display_name_returns_summary_for_known_calendar(mock_get_calendar_service):
+    mock_service = MagicMock()
+    mock_get_calendar_service.return_value = mock_service
+    mock_service.calendarList.return_value.list.return_value.execute.return_value = {
+        "items": [{"id": "team_calendar@example.com", "summary": "Team Calendar"}]
+    }
+
+    label = resolve_calendar_display_name("team_calendar@example.com")
+
+    assert label == "Team Calendar"
+
+
+def test_resolve_calendar_display_name_primary_is_human_readable():
+    assert resolve_calendar_display_name("primary") == "Primary"

--- a/tests/test_confirmation_queue.py
+++ b/tests/test_confirmation_queue.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone, timedelta
 from unittest.mock import patch
 
 from orchestrator.confirmation_queue import add_pending_write
+from orchestrator.confirmation_queue import confirm_write
 from persistence.models import CalendarWriteStatus
 
 
@@ -15,10 +16,45 @@ def test_add_pending_write_serializes_enum_status_before_insert(mock_get_db):
         start_time=start_time,
         end_time=end_time,
         description="Focus block",
+        calendar_id="team_calendar@example.com",
     )
 
     mock_get_db.return_value["calendar_writes"].insert.assert_called_once()
     inserted_row = mock_get_db.return_value["calendar_writes"].insert.call_args.args[0]
     assert inserted_row["status"] == CalendarWriteStatus.PENDING.value
     assert inserted_row["summary"] == "Deep Work"
+    assert inserted_row["calendar_id"] == "team_calendar@example.com"
     assert write_id.startswith("cw_")
+
+
+@patch("orchestrator.confirmation_queue.insert_event")
+@patch("orchestrator.confirmation_queue.get_pending_write")
+@patch("orchestrator.confirmation_queue.get_db")
+def test_confirm_write_persists_created_event_identifiers(
+    mock_get_db,
+    mock_get_pending_write,
+    mock_insert_event,
+):
+    now = datetime.now(timezone.utc)
+    mock_get_pending_write.return_value = type("Record", (), {
+        "status": CalendarWriteStatus.PENDING,
+        "created_at": now.isoformat(),
+        "start_time": now.isoformat(),
+        "end_time": (now + timedelta(hours=1)).isoformat(),
+        "summary": "Team Sync",
+        "description": "Weekly sync",
+        "calendar_id": "team_calendar@example.com",
+    })()
+    mock_insert_event.return_value = {
+        "id": "evt_123",
+        "calendar_id": "team_calendar@example.com",
+    }
+
+    created = confirm_write("cw_abc123")
+
+    assert created["id"] == "evt_123"
+    mock_insert_event.assert_called_once()
+    update_payload = mock_get_db.return_value["calendar_writes"].update.call_args.args[1]
+    assert update_payload["status"] == CalendarWriteStatus.EXECUTED.value
+    assert update_payload["created_event_id"] == "evt_123"
+    assert update_payload["created_event_calendar_id"] == "team_calendar@example.com"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -8,3 +8,12 @@ def test_init_db_creates_expected_tables(tmp_path, monkeypatch):
 
     table_names = set(get_db().table_names())
     assert {"calendar_writes", "sessions", "decisions", "weekly_snapshots"} <= table_names
+
+
+def test_init_db_calendar_writes_includes_multi_calendar_columns(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAVID_DB_PATH", str(tmp_path / "assistant.db"))
+
+    init_db()
+
+    columns = {column.name for column in get_db()["calendar_writes"].columns}
+    assert {"calendar_id", "created_event_id", "created_event_calendar_id"} <= columns

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -484,6 +484,7 @@ async def test_test_schedule_uses_calendar_proposal_helper(mock_send_calendar_pr
     assert kwargs["prefix_text"] == "I propose scheduling 'David UI Test Event' for the next 15 minutes. Does this look good?"
 
 @pytest.mark.asyncio
+@patch('bot.handlers.resolve_calendar_display_name')
 @patch('bot.handlers.track_confirmation_message')
 @patch('bot.handlers.build_calendar_confirmation_keyboard')
 @patch('bot.handlers.add_pending_write')
@@ -491,9 +492,11 @@ async def test_send_calendar_proposal_displays_toronto_time(
     mock_add_pending_write,
     mock_build_keyboard,
     mock_track_confirmation_message,
+    mock_resolve_calendar_display_name,
 ):
     mock_add_pending_write.return_value = "cw_123"
     mock_build_keyboard.return_value = "keyboard"
+    mock_resolve_calendar_display_name.return_value = "Team Calendar"
 
     context = MagicMock()
     context.bot.send_message = AsyncMock(return_value=MagicMock(message_id=999))
@@ -506,7 +509,8 @@ async def test_send_calendar_proposal_displays_toronto_time(
             summary="Coffee Chat",
             start_time="2026-03-31T09:00:00-04:00",
             end_time="2026-03-31T09:30:00-04:00",
-            description="Catch-up downtown."
+            description="Catch-up downtown.",
+            calendar_id="team_calendar@example.com",
         ),
         prefix_text="Want me to schedule this?"
     )
@@ -514,6 +518,7 @@ async def test_send_calendar_proposal_displays_toronto_time(
     context.bot.send_message.assert_awaited_once()
     kwargs = context.bot.send_message.await_args.kwargs
     assert kwargs["chat_id"] == 456
+    assert "Calendar: Team Calendar (`team_calendar@example.com`)" in kwargs["text"]
     assert "Start: 2026-03-31 09:00 EDT" in kwargs["text"]
     assert "End: 2026-03-31 09:30 EDT" in kwargs["text"]
     assert "UTC" not in kwargs["text"]

--- a/tests/test_multi_calendar_integration.py
+++ b/tests/test_multi_calendar_integration.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from orchestrator.confirmation_queue import add_pending_write, confirm_write, get_pending_write
+from persistence.database import init_db
+from persistence.models import CalendarWriteStatus
+
+
+def test_pending_write_round_trip_persists_calendar_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("DAVID_DB_PATH", str(tmp_path / "assistant.db"))
+    init_db()
+
+    start = datetime.now(timezone.utc)
+    end = start + timedelta(minutes=30)
+    write_id = add_pending_write(
+        summary="Integration Test Event",
+        start_time=start,
+        end_time=end,
+        description="validate persistence",
+        calendar_id="team_calendar@example.com",
+    )
+
+    record = get_pending_write(write_id)
+    assert record is not None
+    assert record.calendar_id == "team_calendar@example.com"
+    assert record.status == CalendarWriteStatus.PENDING
+
+
+@patch("orchestrator.confirmation_queue.insert_event")
+def test_confirm_write_persists_event_and_calendar_mapping(mock_insert_event, tmp_path, monkeypatch):
+    monkeypatch.setenv("DAVID_DB_PATH", str(tmp_path / "assistant.db"))
+    init_db()
+
+    start = datetime.now(timezone.utc)
+    end = start + timedelta(minutes=45)
+    write_id = add_pending_write(
+        summary="Team Sync",
+        start_time=start,
+        end_time=end,
+        description="validate executed mapping",
+        calendar_id="team_calendar@example.com",
+    )
+    mock_insert_event.return_value = {
+        "id": "evt_123",
+        "calendar_id": "team_calendar@example.com",
+    }
+
+    created_event = confirm_write(write_id)
+    record = get_pending_write(write_id)
+
+    assert created_event is not None
+    assert created_event["id"] == "evt_123"
+    assert record is not None
+    assert record.status == CalendarWriteStatus.EXECUTED
+    assert record.created_event_id == "evt_123"
+    assert record.created_event_calendar_id == "team_calendar@example.com"


### PR DESCRIPTION
### Motivation

- Enable scheduling and fetching across multiple Google Calendars by carrying a `calendar_id` through proposal creation, persistence, execution, and UI display.
- Show human-friendly calendar names in Telegram confirmation messages to reduce ambiguity when multiple calendars exist.
- Record created event identifiers and their calendar mapping for traceability after execution.

### Description

- Added `calendar_id` to the `ProposedEvent` schema and `CalendarWriteRecord` model and persisted it in the `calendar_writes` table via `init_db` and migration logic, and added `created_event_id` and `created_event_calendar_id` columns.
- Propagated `calendar_id` through the confirmation flow by extending `add_pending_write` and `confirm_write` to include and persist the calendar target, and by storing `created_event_id`/`created_event_calendar_id` when a write is executed.
- Extended the calendar integration: `insert_event` now accepts a `calendar_id` and inserts into the specified calendar, `get_upcoming_events` and `get_past_events` attach `calendar_id` to each returned event, and added `resolve_calendar_display_name` to look up a human-friendly calendar name.
- Updated the Telegram handler `send_calendar_proposal` to display the resolved calendar name/ID in the confirmation message and to pass `calendar_id` when creating pending writes, and adjusted tracking logic accordingly.
- Updated and added unit tests to cover multi-calendar behavior and database schema changes, and updated mocks where necessary.

### Testing

- Ran `pytest tests/test_calendar.py` which verifies `insert_event`, `get_upcoming_events`, `get_past_events`, and `resolve_calendar_display_name`, and it passed.
- Ran `pytest tests/test_confirmation_queue.py` and `pytest tests/test_multi_calendar_integration.py` which validate persistence of `calendar_id` and recording of created event identifiers, and they passed.
- Ran `pytest tests/test_database.py` to ensure DB initialization and migration logic add the new columns, and `pytest tests/test_handlers.py` to verify the updated confirmation UI, and both suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de63b25f04832485c0db81aa391e29)