### PR TITLE
Add cross-layer integration tests to GitHub Actions CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  unit-test:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -35,9 +35,37 @@ jobs:
       - name: Run tests
         run: uv run pytest -q
 
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Sync dependencies
+        run: uv sync
+
+      - name: Run cross-layer integration tests
+        run: >
+          uv run pytest -q
+          tests/test_main.py
+          tests/test_handlers.py
+          tests/test_router.py
+          tests/test_confirmation_queue.py
+          tests/test_context_builder.py
+
   deploy:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-    needs: test
+    needs:
+      - unit-test
+      - integration-test
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to Lightsail over SSH


### PR DESCRIPTION
### Motivation
- Add dedicated integration-level testing to verify interactions across layers and external tools instead of a single monolithic test job. 
- Prevent regressions from cross-layer changes by making deployment wait for both unit and integration suites. 

### Description
- Split the original `test` job into `unit-test` and a new `integration-test` in `.github/workflows/ci-cd.yml`. 
- The `integration-test` job sets up Python and `uv`, runs `uv sync`, and invokes pytest for the cross-layer tests `tests/test_main.py`, `tests/test_handlers.py`, `tests/test_router.py`, `tests/test_confirmation_queue.py`, and `tests/test_context_builder.py`. 
- Updated the `deploy` job to require both `unit-test` and `integration-test` to pass before running on `main`. 

### Testing
- Executed the integration pytest command locally with `uv run pytest -q tests/test_main.py tests/test_handlers.py tests/test_router.py tests/test_confirmation_queue.py tests/test_context_builder.py` to validate the invocation. 
- The local run failed during dependency synchronization because `uv` could not fetch `langfuse` from PyPI due to network/tunnel restrictions, so the tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6959884c83248828b4ac1ca3a845)