### PR TITLE
Suppress transient Telegram transport errors and redact bot tokens in Sentry

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,7 @@
+import httpcore
+import httpx
 from loguru import logger
+from telegram.error import NetworkError, TimedOut
 from telegram.ext import (
     ApplicationBuilder,
     CallbackQueryHandler,
@@ -39,6 +42,14 @@ async def _handle_application_error(update: object, context: ContextTypes.DEFAUL
     if context.error is None:
         return
 
+    if update is None and _is_transient_polling_transport_error(context.error):
+        logger.warning(
+            "Suppressed transient Telegram polling transport error: type={error_type} message={error_message}",
+            error_type=type(context.error).__name__,
+            error_message=str(context.error),
+        )
+        return
+
     capture_sentry_exception(
         context.error,
         component="telegram",
@@ -48,6 +59,34 @@ async def _handle_application_error(update: object, context: ContextTypes.DEFAUL
             "has_update": str(update is not None).lower(),
         },
     )
+
+
+def _walk_exception_chain(error: BaseException):
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def _is_transient_polling_transport_error(error: BaseException) -> bool:
+    transient_error_types = (
+        NetworkError,
+        TimedOut,
+        httpx.ReadError,
+        httpx.ConnectError,
+        httpx.ReadTimeout,
+        httpx.ConnectTimeout,
+        httpcore.ReadError,
+        httpcore.ConnectError,
+        httpcore.ReadTimeout,
+        httpcore.ConnectTimeout,
+        TimeoutError,
+        ConnectionResetError,
+        BrokenPipeError,
+    )
+    return any(isinstance(exc, transient_error_types) for exc in _walk_exception_chain(error))
 
 def main() -> int:
     bootstrap_sentry()

--- a/observability/sentry.py
+++ b/observability/sentry.py
@@ -1,8 +1,31 @@
 import os
+import re
 from typing import Mapping
 
 import sentry_sdk
 from loguru import logger
+
+_TELEGRAM_BOT_TOKEN_PATTERN = re.compile(r"/bot\d+:[^/\s]+")
+
+
+def _redact_text(value: str) -> str:
+    return _TELEGRAM_BOT_TOKEN_PATTERN.sub("/bot<redacted>", value)
+
+
+def _scrub(value):
+    if isinstance(value, str):
+        return _redact_text(value)
+    if isinstance(value, dict):
+        return {key: _scrub(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_scrub(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_scrub(item) for item in value)
+    return value
+
+
+def _before_send(event: dict, hint: dict) -> dict:
+    return _scrub(event)
 
 
 def init_sentry() -> bool:
@@ -23,6 +46,7 @@ def init_sentry() -> bool:
         release=os.getenv("DAVID_RELEASE"),
         send_default_pii=False,
         enable_tracing=False,
+        before_send=_before_send,
     )
     sentry_sdk.set_tag("service", "david")
     logger.info("Sentry is enabled for runtime error reporting.")
@@ -44,8 +68,16 @@ def capture_exception(
     `tags` carries any additional workflow-specific context such as session or
     trigger identifiers.
     """
+    redacted_message = _redact_text(message) if message else None
+    redacted_error_text = _redact_text(str(error))
+
     if message:
-        logger.opt(exception=error).error(message)
+        logger.error(
+            "Exception captured: message={message} error_type={error_type} error={error}",
+            message=redacted_message,
+            error_type=type(error).__name__,
+            error=redacted_error_text,
+        )
 
     with sentry_sdk.new_scope() as scope:
         scope.set_tag("component", component)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 import asyncio
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import main
 
@@ -46,6 +46,7 @@ def test_init_sentry_initializes_sdk_when_dsn_is_present(
         release="test-release",
         send_default_pii=False,
         enable_tracing=False,
+        before_send=ANY,
     )
     mock_set_tag.assert_called_once_with("service", "david")
     mock_logger.info.assert_called_once_with(
@@ -184,8 +185,12 @@ def test_capture_app_exception_logs_and_reports_with_tags(
         tags={"token_path": "/tmp/token.json"},
     )
 
-    mock_logger.opt.assert_called_once_with(exception=error)
-    mock_logger.opt.return_value.error.assert_called_once_with("Captured app failure")
+    mock_logger.error.assert_called_once_with(
+        "Exception captured: message={message} error_type={error_type} error={error}",
+        message="Captured app failure",
+        error_type="RuntimeError",
+        error="boom",
+    )
     assert scope.set_tag.call_args_list == [
         (("component", "calendar_auth"),),
         (("operation", "refresh_token"),),


### PR DESCRIPTION
### Motivation
- Reduce noisy Sentry events caused by transient Telegram polling/network transport failures that occur outside of handler updates. 
- Prevent accidental leakage of raw Telegram bot tokens in logs and Sentry events by redacting token-like patterns.

### Description
- Add a suppression path in `_handle_application_error` that returns early (and logs a one-line warning) when `update is None` and the exception chain contains a known transient transport/network error type. 
- Implement `_walk_exception_chain` to iterate `__cause__`/`__context__` safely and `_is_transient_polling_transport_error` to match the requested transient types from `telegram.error`, `httpx`, `httpcore`, and builtin connection/timeout errors. 
- Add token-redaction helpers in `observability/sentry.py`: `_redact_text`, `_scrub`, and a `before_send` hook to recursively sanitize string payloads so patterns like `/bot123456:ABCDEF...` become `/bot<redacted>`. 
- Replace `logger.opt(exception=error).error(message)` with a structured, safer log that emits `message`, `error_type`, and a redacted `str(error)` instead of emitting the full traceback by default, and wire `before_send` into the Sentry initialization while preserving existing tags and setup.

### Testing
- Verified that the modified modules compile successfully with `python -m compileall main.py observability/sentry.py` and the compile step completed without errors. 
- Ran a diff/inspection of the two updated files to confirm only the targeted changes were introduced. 
- No additional automated test suite was added or executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51f3eddd48324b4a49bfe45f95d4a)